### PR TITLE
feat: bootstrap chromium tab grouping extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# chromium-tab-grouper
+# Chromium Tab Grouper
+
+A starter Chromium extension that will group browser tabs using AI suggestions.
+
+## Features
+
+- Browser action button groups the two rightmost tabs into a test group titled "Test".
+- Options page allows storing a Gemini API key for future AI integration.
+
+## Development
+
+1. Load the extension in developer mode in Chromium-based browsers.
+2. Click the toolbar button to group the two rightmost tabs into a "Test" group.
+3. Open the extension options to save your Gemini API key.
+
+This is a placeholder scaffold; the AI grouping logic will be implemented later.

--- a/background.js
+++ b/background.js
@@ -1,0 +1,10 @@
+chrome.action.onClicked.addListener(async () => {
+  const tabs = await chrome.tabs.query({ currentWindow: true });
+  if (tabs.length < 2) {
+    return;
+  }
+  const lastTabs = tabs.slice(-2);
+  const tabIds = lastTabs.map(t => t.id);
+  const groupId = await chrome.tabs.group({ tabIds });
+  await chrome.tabGroups.update(groupId, { title: 'Test' });
+});

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,14 @@
+{
+  "manifest_version": 3,
+  "name": "Chromium Tab Grouper",
+  "version": "0.1.0",
+  "description": "Groups tabs based on AI suggestions.",
+  "permissions": ["tabs", "tabGroups", "storage"],
+  "action": {
+    "default_title": "Group tabs"
+  },
+  "background": {
+    "service_worker": "background.js"
+  },
+  "options_page": "options.html"
+}

--- a/options.html
+++ b/options.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Tab Grouper Settings</title>
+</head>
+<body>
+  <h1>Settings</h1>
+  <label>
+    Gemini API Key:
+    <input type="text" id="apiKey" />
+  </label>
+  <button id="save">Save</button>
+  <div id="status"></div>
+  <script src="options.js"></script>
+</body>
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,15 @@
+document.addEventListener('DOMContentLoaded', () => {
+  chrome.storage.sync.get('apiKey', (items) => {
+    document.getElementById('apiKey').value = items.apiKey || '';
+  });
+  document.getElementById('save').addEventListener('click', () => {
+    const apiKey = document.getElementById('apiKey').value;
+    chrome.storage.sync.set({ apiKey }, () => {
+      const status = document.getElementById('status');
+      status.textContent = 'Saved';
+      setTimeout(() => {
+        status.textContent = '';
+      }, 1000);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- scaffold a manifest v3 extension with toolbar button
- group two rightmost tabs into a temporary "Test" group
- add options page to store Gemini API key
- remove placeholder icon assets

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a81e6188b483219faeda96b082cb0f