### PR TITLE
Integrate Gemini API for tab grouping

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,6 +4,7 @@
   "version": "0.1.0",
   "description": "Groups tabs based on AI suggestions.",
   "permissions": ["tabs", "tabGroups", "storage"],
+  "host_permissions": ["https://generativelanguage.googleapis.com/*"],
   "action": {
     "default_title": "Group tabs",
     "default_popup": "popup.html"

--- a/options.html
+++ b/options.html
@@ -10,6 +10,10 @@
     Gemini API Key:
     <input type="text" id="apiKey" />
   </label>
+  <label>
+    Context:
+    <textarea id="context"></textarea>
+  </label>
   <button id="save">Save</button>
   <div id="status"></div>
   <script src="options.js"></script>

--- a/options.js
+++ b/options.js
@@ -1,10 +1,12 @@
 document.addEventListener('DOMContentLoaded', () => {
-  chrome.storage.sync.get('apiKey', (items) => {
+  chrome.storage.sync.get(['apiKey', 'context'], (items) => {
     document.getElementById('apiKey').value = items.apiKey || '';
+    document.getElementById('context').value = items.context || '';
   });
   document.getElementById('save').addEventListener('click', () => {
     const apiKey = document.getElementById('apiKey').value;
-    chrome.storage.sync.set({ apiKey }, () => {
+    const context = document.getElementById('context').value;
+    chrome.storage.sync.set({ apiKey, context }, () => {
       const status = document.getElementById('status');
       status.textContent = 'Saved';
       setTimeout(() => {

--- a/popup.html
+++ b/popup.html
@@ -9,6 +9,7 @@
   </style>
 </head>
 <body>
+  <button id="ask-ai">Сгруппировать</button>
   <pre id="tab-json"></pre>
   <script src="popup.js"></script>
 </body>

--- a/popup.js
+++ b/popup.js
@@ -1,12 +1,43 @@
 document.addEventListener('DOMContentLoaded', async () => {
   const tabs = await chrome.tabs.query({ currentWindow: true });
-  if (tabs.length >= 2) {
-    const lastTabs = tabs.slice(-2);
-    const tabIds = lastTabs.map(t => t.id);
-    const groupId = await chrome.tabs.group({ tabIds });
-    await chrome.tabGroups.update(groupId, { title: 'Test' });
-  }
-  const updatedTabs = await chrome.tabs.query({ currentWindow: true });
-  const tabInfo = updatedTabs.map(t => ({ id: t.id, title: t.title }));
-  document.getElementById('tab-json').textContent = JSON.stringify(tabInfo, null, 2);
+  const tabInfo = tabs.map(t => ({ id: t.id, title: t.title, url: t.url }));
+  const pre = document.getElementById('tab-json');
+  pre.textContent = JSON.stringify(tabInfo, null, 2);
+
+  document.getElementById('ask-ai').addEventListener('click', async () => {
+    pre.textContent = 'Обращение к ИИ...';
+    const { apiKey, context } = await chrome.storage.sync.get(['apiKey', 'context']);
+    if (!apiKey) {
+      pre.textContent = 'API key not set.';
+      return;
+    }
+    const task = `Твоя задача ознакомиться со списком вкладок в формате JSON и предложить свою сортировку исходя из контекста, который предоставит пользователь. Вернуть ты должен такой же JSON, как исходный, но с нужным порядком вкладок и группировкой. Названия групп должны быть максимально короткие и желательно односложные. Контекст от пользователя: ${context || ''}`;
+    const body = {
+      contents: [
+        {
+          role: 'user',
+          parts: [
+            { text: `${task}\n\n${JSON.stringify(tabInfo, null, 2)}` }
+          ]
+        }
+      ]
+    };
+    try {
+      const res = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=${apiKey}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+      });
+      const data = await res.json();
+      const text = data.candidates?.[0]?.content?.parts?.[0]?.text || 'No response from AI.';
+      try {
+        const parsed = JSON.parse(text);
+        pre.textContent = JSON.stringify(parsed, null, 2);
+      } catch (e) {
+        pre.textContent = text;
+      }
+    } catch (e) {
+      pre.textContent = 'Error contacting AI.';
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- add user context settings and use stored API key
- call Gemini to reorder tab JSON on button click with loading state
- allow extension to access Gemini API endpoint

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a825fd824c8321873b7fb6f900e999