### PR TITLE
Handle Gemini API errors and update model

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A starter Chromium extension that will group browser tabs using AI suggestions.
 ## Features
 
 - Browser action button groups the two rightmost tabs into a test group titled "Test" and shows a popup listing all open tabs as JSON with their IDs and titles.
+- Popup can send the open tab list to Google's Gemini (using the `gemini-2.5-flash` model) and displays the AI response or any API error.
 - Options page allows storing a Gemini API key for future AI integration.
 
 ## Development

--- a/popup.js
+++ b/popup.js
@@ -12,6 +12,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       return;
     }
     const task = `Твоя задача ознакомиться со списком вкладок в формате JSON и предложить свою сортировку исходя из контекста, который предоставит пользователь. Вернуть ты должен такой же JSON, как исходный, но с нужным порядком вкладок и группировкой. Названия групп должны быть максимально короткие и желательно односложные. Контекст от пользователя: ${context || ''}`;
+
     const body = {
       contents: [
         {
@@ -22,19 +23,25 @@ document.addEventListener('DOMContentLoaded', async () => {
         }
       ]
     };
+
+    const model = 'gemini-2.5-flash';
     try {
-      const res = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=${apiKey}`, {
+      const res = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body)
       });
       const data = await res.json();
-      const text = data.candidates?.[0]?.content?.parts?.[0]?.text || 'No response from AI.';
-      try {
-        const parsed = JSON.parse(text);
-        pre.textContent = JSON.stringify(parsed, null, 2);
-      } catch (e) {
-        pre.textContent = text;
+      if (res.ok && data.candidates?.length) {
+        const text = data.candidates[0].content.parts.map(p => p.text || '').join('');
+        try {
+          const parsed = JSON.parse(text);
+          pre.textContent = JSON.stringify(parsed, null, 2);
+        } catch (e) {
+          pre.textContent = text;
+        }
+      } else {
+        pre.textContent = data.error?.message || 'No response from AI.';
       }
     } catch (e) {
       pre.textContent = 'Error contacting AI.';


### PR DESCRIPTION
## Summary
- Switch popup AI requests to the `gemini-2.5-flash` model
- Surface Gemini API error messages instead of generic 'No response'
- Document Gemini integration in the README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a827d594e48321af8a3afa4d9781d1