### PR TITLE
Handle pinned tabs and surface grouping failures

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -1,5 +1,5 @@
 document.addEventListener('DOMContentLoaded', async () => {
-  const tabs = await chrome.tabs.query({ currentWindow: true });
+  const tabs = (await chrome.tabs.query({ currentWindow: true })).filter(t => !t.pinned);
   const tabInfo = tabs.map(t => ({ id: t.id, title: t.title, url: t.url }));
   const pre = document.getElementById('tab-json');
   pre.textContent = JSON.stringify(tabInfo, null, 2);
@@ -89,7 +89,8 @@ document.addEventListener('DOMContentLoaded', async () => {
             await chrome.tabGroups.update(groupId, { title: grp.title || '' });
           }
         } catch (e) {
-          pre.textContent = text;
+          console.error(e);
+          pre.textContent = 'Ошибка при группировке вкладок: ' + (e.message || '');
         }
       } else {
         pre.textContent = data.error?.message || 'No response from AI.';


### PR DESCRIPTION
## Summary
- ignore pinned tabs when asking AI to group tabs
- show a clear error if tab grouping fails

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a835fa20dc8321ad126b976ea814e6