### PR TITLE
Add popup UI with sort button

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,8 @@
   "permissions": ["tabs", "tabGroups", "storage", "contextMenus"],
   "host_permissions": ["https://generativelanguage.googleapis.com/*"],
   "action": {
-    "default_title": "Chromium Tab Grouper"
+    "default_title": "Chromium Tab Grouper",
+    "default_popup": "popup.html"
   },
   "background": {
     "service_worker": "background.js"

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <style>
+    body {
+      margin: 0;
+      width: 320px;
+      height: 320px;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      background: #fff;
+    }
+    #sortBtn {
+      padding: 20px 30px;
+      font-size: 20px;
+      background: orange;
+      color: #fff;
+      border: none;
+      border-radius: 8px;
+      cursor: pointer;
+    }
+    #statusImage {
+      max-width: 100%;
+      max-height: 100%;
+      display: none;
+    }
+  </style>
+</head>
+<body>
+  <button id="sortBtn">Sort Tabs</button>
+  <img id="statusImage" src="" alt="status" />
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,22 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const btn = document.getElementById('sortBtn');
+  const img = document.getElementById('statusImage');
+
+  function showImage(path) {
+    img.src = path;
+    img.style.display = 'block';
+  }
+
+  btn.addEventListener('click', () => {
+    btn.style.display = 'none';
+    showImage('src/test.gif');
+
+    chrome.runtime.sendMessage({ type: 'groupTabs' }, (response) => {
+      if (chrome.runtime.lastError || !response || response.status !== 'success') {
+        showImage('src/error.gif');
+        return;
+      }
+      showImage('src/success.gif');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add a 320x320 popup with a large orange "Sort Tabs" button
- Replace button with loading/success/error images based on grouping result
- Wire popup to background via messaging and return success status

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68a83c2712e48321b039d4fed48104bd