### PR TITLE
style: modernize options page

### DIFF
--- a/options.css
+++ b/options.css
@@ -1,0 +1,73 @@
+body {
+  font-family: system-ui, sans-serif;
+  background: #f4f4f4;
+  margin: 0;
+  padding: 0;
+}
+
+.container {
+  max-width: 600px;
+  margin: 40px auto;
+  background: #fff;
+  padding: 24px;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+h1 {
+  margin-top: 0;
+  text-align: center;
+}
+
+.field {
+  margin-top: 20px;
+}
+
+label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+input[type="text"], textarea {
+  width: 100%;
+  padding: 10px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 14px;
+  box-sizing: border-box;
+}
+
+textarea {
+  min-height: 150px;
+  resize: vertical;
+}
+
+.explainer {
+  font-size: 12px;
+  color: #666;
+  margin-top: 4px;
+}
+
+button#save {
+  margin-top: 30px;
+  width: 100%;
+  padding: 12px;
+  background: #4a90e2;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  font-size: 16px;
+  cursor: pointer;
+}
+
+button#save:hover {
+  background: #357ABD;
+}
+
+#status {
+  margin-top: 12px;
+  text-align: center;
+  color: #4a90e2;
+  font-size: 14px;
+}

--- a/options.html
+++ b/options.html
@@ -3,19 +3,27 @@
 <head>
   <meta charset="utf-8">
   <title>Tab Grouper Settings</title>
+  <link rel="stylesheet" href="options.css">
 </head>
 <body>
-  <h1>Settings</h1>
-  <label>
-    Gemini API Key:
-    <input type="text" id="apiKey" />
-  </label>
-  <label>
-    Context:
-    <textarea id="context"></textarea>
-  </label>
-  <button id="save">Save</button>
-  <div id="status"></div>
+  <div class="container">
+    <h1>Settings</h1>
+
+    <div class="field">
+      <label for="apiKey">Gemini API Key</label>
+      <input type="text" id="apiKey" placeholder="Enter your Gemini API key">
+      <p class="explainer">Used to fetch grouping suggestions from Gemini.</p>
+    </div>
+
+    <div class="field">
+      <label for="context">Context</label>
+      <textarea id="context" placeholder="Optional context for grouping"></textarea>
+      <p class="explainer">Provide additional instructions sent with each grouping request.</p>
+    </div>
+
+    <button id="save">Save</button>
+    <div id="status"></div>
+  </div>
   <script src="options.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- revamp settings page with clean layout and explainers
- add dedicated CSS for modern styling and larger textarea

## Testing
- `npm test` *(fails: ENOENT, package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a861af938c832183a3b1a1e9ec8eb4